### PR TITLE
tiny bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /server_files/
-/downloaded_files/
 /dist/
 /Output/
 /config.json

--- a/auto_update.py
+++ b/auto_update.py
@@ -3,6 +3,8 @@ import os
 import requests
 import tqdm
 
+import sys
+
 from env import VERSION
 from shared import lang, info, error, success
 
@@ -30,7 +32,7 @@ def download_update() -> None:
     else:
         success(lang["update.info.updateDownloaded"])
         os.startfile("Setup-x64.exe")
-        exit(0)
+        sys.exit(0)
 
 
 def check_for_updates() -> None:

--- a/env.py
+++ b/env.py
@@ -1,6 +1,6 @@
 from colorama import Fore
 
-VERSION = "v1.7.1"
+VERSION = "v1.7.2"
 TITLE = f"""
 {Fore.LIGHTYELLOW_EX}ZapFiles {Fore.LIGHTWHITE_EX}{VERSION}
 {Fore.LIGHTYELLOW_EX}Made with 💖 by {Fore.LIGHTBLUE_EX}Meynrun

--- a/setup_script.iss
+++ b/setup_script.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "ZapFiles"
-#define MyAppVersion "1.7.1"
+#define MyAppVersion "1.7.2"
 #define MyAppPublisher "MeynDev"
 #define MyAppURL "https://github.com/meynrun/ZapFiles"
 #define MyAppExeName "main.exe"


### PR DESCRIPTION
fix bug that caused "NameError: name 'exit' is not defined" to be displayed in the console when launching the installer of a new version